### PR TITLE
Fixing argument type conversion bug #13

### DIFF
--- a/scripts/nrtest
+++ b/scripts/nrtest
@@ -91,10 +91,10 @@ if __name__ == '__main__':
     c_parser.set_defaults(func=compare)
     c_parser.add_argument('new', metavar='new_benchmark')
     c_parser.add_argument('old', metavar='old_benchmark')
-    c_parser.add_argument('--rtol', default=0.01,
+    c_parser.add_argument('--rtol', type=float, default=0.01,
                           help='Relative precision at which results \
                           considered compatible')
-    c_parser.add_argument('--atol', default=0.0,
+    c_parser.add_argument('--atol', type=float, default=0.0,
                           help='Absolute precision at which results \
                           considered compatible')
 


### PR DESCRIPTION
When running nrtest on Windows an error is generated because rtol and atol command line arguments aren't being converted from string to float. This can be fixed by specifying the argument type when adding the arguments in the nrtest script.
